### PR TITLE
Simplify accessing PlanResourceChange

### DIFF
--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -695,6 +695,254 @@ func (s *GRPCProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Re
 	return resp, nil
 }
 
+func (s *GRPCProviderServer) PlanResourceChangeLogical(
+	ctx context.Context,
+	req *tfprotov5.PlanResourceChangeRequest,
+) (*tfprotov5.PlanResourceChangeResponse, error) {
+	ctx = logging.InitContext(ctx)
+	resp := &tfprotov5.PlanResourceChangeResponse{}
+
+	res, ok := s.provider.ResourcesMap[req.TypeName]
+	if !ok {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, fmt.Errorf("unknown resource type: %s", req.TypeName))
+		return resp, nil
+	}
+	schemaBlock := s.getResourceSchemaBlock(req.TypeName)
+
+	// This is a signal to Terraform Core that we're doing the best we can to
+	// shim the legacy type system of the SDK onto the Terraform type system
+	// but we need it to cut us some slack. This setting should not be taken
+	// forward to any new SDK implementations, since setting it prevents us
+	// from catching certain classes of provider bug that can lead to
+	// confusing downstream errors.
+	if !res.EnableLegacyTypeSystemPlanErrors {
+		//nolint:staticcheck // explicitly for this SDK
+		resp.UnsafeToUseLegacyTypeSystem = true
+	}
+
+	priorStateVal, err := msgpack.Unmarshal(req.PriorState.MsgPack, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	create := priorStateVal.IsNull()
+
+	proposedNewStateVal, err := msgpack.Unmarshal(req.ProposedNewState.MsgPack, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	// We don't usually plan destroys, but this can return early in any case.
+	if proposedNewStateVal.IsNull() {
+		resp.PlannedState = req.ProposedNewState
+		resp.PlannedPrivate = req.PriorPrivate
+		return resp, nil
+	}
+
+	configVal, err := msgpack.Unmarshal(req.Config.MsgPack, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	priorState, err := res.ShimInstanceStateFromValue(priorStateVal)
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+	priorState.RawState = priorStateVal
+	priorState.RawPlan = proposedNewStateVal
+	priorState.RawConfig = configVal
+	priorPrivate := make(map[string]interface{})
+	if len(req.PriorPrivate) > 0 {
+		if err := json.Unmarshal(req.PriorPrivate, &priorPrivate); err != nil {
+			resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+			return resp, nil
+		}
+	}
+
+	priorState.Meta = priorPrivate
+
+	pmSchemaBlock := s.getProviderMetaSchemaBlock()
+	if pmSchemaBlock != nil && req.ProviderMeta != nil {
+		providerSchemaVal, err := msgpack.Unmarshal(req.ProviderMeta.MsgPack, pmSchemaBlock.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+			return resp, nil
+		}
+		priorState.ProviderMeta = providerSchemaVal
+	}
+
+	// Ensure there are no nulls that will cause helper/schema to panic.
+	if err := validateConfigNulls(ctx, proposedNewStateVal, nil); err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	// turn the proposed state into a legacy configuration
+	cfg := terraform.NewResourceConfigShimmed(proposedNewStateVal, schemaBlock)
+
+	diff, err := res.SimpleDiff(ctx, priorState, cfg, s.provider.Meta())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	// if this is a new instance, we need to make sure ID is going to be computed
+	if create {
+		if diff == nil {
+			diff = terraform.NewInstanceDiff()
+		}
+
+		diff.Attributes["id"] = &terraform.ResourceAttrDiff{
+			NewComputed: true,
+		}
+	}
+
+	if diff == nil || len(diff.Attributes) == 0 {
+		// schema.Provider.Diff returns nil if it ends up making a diff with no
+		// changes, but our new interface wants us to return an actual change
+		// description that _shows_ there are no changes. This is always the
+		// prior state, because we force a diff above if this is a new instance.
+		resp.PlannedState = req.PriorState
+		resp.PlannedPrivate = req.PriorPrivate
+		return resp, nil
+	}
+
+	if priorState == nil {
+		priorState = &terraform.InstanceState{}
+	}
+
+	// now we need to apply the diff to the prior state, so get the planned state
+	plannedAttrs, err := diff.Apply(priorState.Attributes, schemaBlock)
+
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	plannedStateVal, err := hcl2shim.HCL2ValueFromFlatmap(plannedAttrs, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	plannedStateVal, err = schemaBlock.CoerceValue(plannedStateVal)
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	plannedStateVal = normalizeNullValues(plannedStateVal, proposedNewStateVal, false)
+
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	plannedStateVal = copyTimeoutValues(plannedStateVal, proposedNewStateVal)
+
+	// The old SDK code has some imprecisions that cause it to sometimes
+	// generate differences that the SDK itself does not consider significant
+	// but Terraform Core would. To avoid producing weird do-nothing diffs
+	// in that case, we'll check if the provider as produced something we
+	// think is "equivalent" to the prior state and just return the prior state
+	// itself if so, thus ensuring that Terraform Core will treat this as
+	// a no-op. See the docs for ValuesSDKEquivalent for some caveats on its
+	// accuracy.
+	forceNoChanges := false
+	if hcl2shim.ValuesSDKEquivalent(priorStateVal, plannedStateVal) {
+		plannedStateVal = priorStateVal
+		forceNoChanges = true
+	}
+
+	// if this was creating the resource, we need to set any remaining computed
+	// fields
+	if create {
+		plannedStateVal = SetUnknowns(plannedStateVal, schemaBlock)
+	}
+
+	plannedMP, err := msgpack.Marshal(plannedStateVal, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+	resp.PlannedState = &tfprotov5.DynamicValue{
+		MsgPack: plannedMP,
+	}
+
+	// encode any timeouts into the diff Meta
+	t := &ResourceTimeout{}
+	if err := t.ConfigDecode(res, cfg); err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	if err := t.DiffEncode(diff); err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	// Now we need to store any NewExtra values, which are where any actual
+	// StateFunc modified config fields are hidden.
+	privateMap := diff.Meta
+	if privateMap == nil {
+		privateMap = map[string]interface{}{}
+	}
+
+	newExtra := map[string]interface{}{}
+
+	for k, v := range diff.Attributes {
+		if v.NewExtra != nil {
+			newExtra[k] = v.NewExtra
+		}
+	}
+	privateMap[newExtraKey] = newExtra
+
+	// the Meta field gets encoded into PlannedPrivate
+	plannedPrivate, err := json.Marshal(privateMap)
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+	resp.PlannedPrivate = plannedPrivate
+
+	// collect the attributes that require instance replacement, and convert
+	// them to cty.Paths.
+	var requiresNew []string
+	if !forceNoChanges {
+		for attr, d := range diff.Attributes {
+			if d.RequiresNew {
+				requiresNew = append(requiresNew, attr)
+			}
+		}
+	}
+
+	// If anything requires a new resource already, or the "id" field indicates
+	// that we will be creating a new resource, then we need to add that to
+	// RequiresReplace so that core can tell if the instance is being replaced
+	// even if changes are being suppressed via "ignore_changes".
+	id := plannedStateVal.GetAttr("id")
+	if len(requiresNew) > 0 || id.IsNull() || !id.IsKnown() {
+		requiresNew = append(requiresNew, "id")
+	}
+
+	requiresReplace, err := hcl2shim.RequiresReplace(requiresNew, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)
+		return resp, nil
+	}
+
+	// convert these to the protocol structures
+	for _, p := range requiresReplace {
+		resp.RequiresReplace = append(resp.RequiresReplace, pathToAttributePath(p))
+	}
+
+	return resp, nil
+}
+
 func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
 	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.PlanResourceChangeResponse{}

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -716,6 +716,58 @@ type PlanResourceChangeLogicalResponse struct {
 	InstanceDiff                *terraform.InstanceDiff
 }
 
+type SimplePlanResourceChangeLogicalRequest struct {
+	ResourceName        string
+	ConfigVal           cty.Value
+	PriorStateVal       cty.Value
+	ProposedNewStateVal cty.Value
+	ProviderMetaVal     *cty.Value
+	PriorPrivateState   map[string]interface{}
+}
+
+var _ PlanResourceChangeLogicalRequest = (*SimplePlanResourceChangeLogicalRequest)(nil)
+
+func (r *SimplePlanResourceChangeLogicalRequest) TypeName() string {
+	return r.ResourceName
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) PriorState() (cty.Value, error) {
+	return r.PriorStateVal, nil
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) ProposedNewState() (cty.Value, error) {
+	return r.ProposedNewStateVal, nil
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) HasPriorPrivate() bool {
+	return len(r.PriorPrivateState) > 0
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) PriorPrivate() (map[string]interface{}, error) {
+	return r.PriorPrivateState, nil
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) Config() (cty.Value, error) {
+	return r.ConfigVal, nil
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) HasProviderMeta() bool {
+	return r.ProviderMetaVal != nil
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) ProviderMeta() (cty.Value, error) {
+	if r.ProviderMetaVal == nil {
+		return cty.NilVal, fmt.Errorf("no ProviderMeta value available")
+	}
+	return *r.ProviderMetaVal, nil
+}
+
+func (r *SimplePlanResourceChangeLogicalRequest) TransformInstanceDiff(
+	d *terraform.InstanceDiff,
+) *terraform.InstanceDiff {
+	return d
+}
+
 type planResourceChangeAdaptedRequest struct {
 	req *tfprotov5.PlanResourceChangeRequest
 	ty  cty.Type

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -717,12 +717,13 @@ type PlanResourceChangeLogicalResponse struct {
 }
 
 type SimplePlanResourceChangeLogicalRequest struct {
-	ResourceName        string
-	ConfigVal           cty.Value
-	PriorStateVal       cty.Value
-	ProposedNewStateVal cty.Value
-	ProviderMetaVal     *cty.Value
-	PriorPrivateState   map[string]interface{}
+	ResourceName          string
+	ConfigVal             cty.Value
+	PriorStateVal         cty.Value
+	ProposedNewStateVal   cty.Value
+	ProviderMetaVal       *cty.Value
+	PriorPrivateState     map[string]interface{}
+	InstanceDiffTransform func(*terraform.InstanceDiff) *terraform.InstanceDiff
 }
 
 var _ PlanResourceChangeLogicalRequest = (*SimplePlanResourceChangeLogicalRequest)(nil)
@@ -765,6 +766,9 @@ func (r *SimplePlanResourceChangeLogicalRequest) ProviderMeta() (cty.Value, erro
 func (r *SimplePlanResourceChangeLogicalRequest) TransformInstanceDiff(
 	d *terraform.InstanceDiff,
 ) *terraform.InstanceDiff {
+	if r.InstanceDiffTransform != nil {
+		return r.InstanceDiffTransform(d)
+	}
 	return d
 }
 

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -714,7 +714,7 @@ type PlanResourceChangeLogicalResponse struct {
 	PlannedState                cty.Value
 	PlannedPrivate              map[string]interface{}
 	RequiresReplace             []cty.Path
-	InscanceDiff                *terraform.InstanceDiff
+	InstanceDiff                *terraform.InstanceDiff
 }
 
 func (s *GRPCProviderServer) PlanResourceChangeLogical(
@@ -824,7 +824,7 @@ func (s *GRPCProviderServer) PlanResourceChangeLogical(
 		}
 	}
 
-	resp.InscanceDiff = diff
+	resp.InstanceDiff = diff
 
 	if diff == nil || len(diff.Attributes) == 0 {
 		// schema.Provider.Diff returns nil if it ends up making a diff with no


### PR DESCRIPTION
Motivation: https://github.com/pulumi/pulumi-terraform-bridge/pull/1614

The bridge is trying to integrate deeper with `(*GRPCProviderServer) PlanResourceChange` so this patch makes it a little easier:

- expose the constructed InstanceDiff object 
- apply Pulumi-specified ignore changes to the InstanceDiff object before it gets used to compute the plan
