### PR TITLE
Hack resource validate

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -244,8 +244,7 @@ func (p *Provider) Validate(c *terraform.ResourceConfig) diag.Diagnostics {
 // The primary use case of this call is to check that the required keys
 // are set and that the general structure is correct.
 func (p *Provider) ValidateResource(
-	t string, c *terraform.ResourceConfig,
-) diag.Diagnostics {
+	t string, c *terraform.ResourceConfig) diag.Diagnostics {
 	r, ok := p.ResourcesMap[t]
 	if !ok {
 		return []diag.Diagnostic{
@@ -362,8 +361,7 @@ func (p *Provider) Resources() []terraform.ResourceType {
 func (p *Provider) ImportState(
 	ctx context.Context,
 	info *terraform.InstanceInfo,
-	id string,
-) ([]*terraform.InstanceState, error) {
+	id string) ([]*terraform.InstanceState, error) {
 	// Find the resource
 	r, ok := p.ResourcesMap[info.Type]
 	if !ok {
@@ -443,8 +441,7 @@ func (p *Provider) ImportState(
 // The primary use case of this call is to check that the required keys
 // are set and that the general structure is correct.
 func (p *Provider) ValidateDataSource(
-	t string, c *terraform.ResourceConfig,
-) diag.Diagnostics {
+	t string, c *terraform.ResourceConfig) diag.Diagnostics {
 	r, ok := p.DataSourcesMap[t]
 	if !ok {
 		return []diag.Diagnostic{

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -143,17 +143,17 @@ func (p *Provider) InternalValidate() error {
 		}
 	}
 
-	for k, r := range p.ResourcesMap {
-		if err := r.InternalValidate(nil, true); err != nil {
-			validationErrors = multierror.Append(validationErrors, fmt.Errorf("resource %s: %s", k, err))
-		}
-	}
+	// for k, r := range p.ResourcesMap {
+	// 	if err := r.InternalValidate(nil, true); err != nil {
+	// 		validationErrors = multierror.Append(validationErrors, fmt.Errorf("resource %s: %s", k, err))
+	// 	}
+	// }
 
-	for k, r := range p.DataSourcesMap {
-		if err := r.InternalValidate(nil, false); err != nil {
-			validationErrors = multierror.Append(validationErrors, fmt.Errorf("data source %s: %s", k, err))
-		}
-	}
+	// for k, r := range p.DataSourcesMap {
+	// 	if err := r.InternalValidate(nil, false); err != nil {
+	// 		validationErrors = multierror.Append(validationErrors, fmt.Errorf("data source %s: %s", k, err))
+	// 	}
+	// }
 
 	return validationErrors
 }
@@ -244,7 +244,8 @@ func (p *Provider) Validate(c *terraform.ResourceConfig) diag.Diagnostics {
 // The primary use case of this call is to check that the required keys
 // are set and that the general structure is correct.
 func (p *Provider) ValidateResource(
-	t string, c *terraform.ResourceConfig) diag.Diagnostics {
+	t string, c *terraform.ResourceConfig,
+) diag.Diagnostics {
 	r, ok := p.ResourcesMap[t]
 	if !ok {
 		return []diag.Diagnostic{
@@ -361,7 +362,8 @@ func (p *Provider) Resources() []terraform.ResourceType {
 func (p *Provider) ImportState(
 	ctx context.Context,
 	info *terraform.InstanceInfo,
-	id string) ([]*terraform.InstanceState, error) {
+	id string,
+) ([]*terraform.InstanceState, error) {
 	// Find the resource
 	r, ok := p.ResourcesMap[info.Type]
 	if !ok {
@@ -441,7 +443,8 @@ func (p *Provider) ImportState(
 // The primary use case of this call is to check that the required keys
 // are set and that the general structure is correct.
 func (p *Provider) ValidateDataSource(
-	t string, c *terraform.ResourceConfig) diag.Diagnostics {
+	t string, c *terraform.ResourceConfig,
+) diag.Diagnostics {
 	r, ok := p.DataSourcesMap[t]
 	if !ok {
 		return []diag.Diagnostic{


### PR DESCRIPTION
Looks like the resource and data source internalValidate are called during provider validation.

These seem unnecessary and it looks to me like we can just call them during tfgen.